### PR TITLE
fix(package): define exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
     "SSE",
     "sse"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    }
+  },
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "browser": "dist/index.iife.js",


### PR DESCRIPTION
Resolves https://github.com/lukas-reining/eventsource/issues/3

Webpack would otherwise bundle IIFE instead of CJS.