### PR TITLE
feature: support custom fetch implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extended-eventsource",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extended-eventsource",
-      "version": "1.4.8",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extended-eventsource",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "author": "Lukas Reining",
   "readme": "README.md",
   "description": "Spec compliant EventSource implementation for browsers and Node.JS",

--- a/src/eventsource.spec.ts
+++ b/src/eventsource.spec.ts
@@ -45,6 +45,30 @@ describe('EventSource', () => {
     ev.onopen = () => done();
   });
 
+  it('allows for a custom fetch implementation to be used', (done) => {
+    mockChunks();
+
+    const fetchFn = jest.fn((input, init?) => {
+      return globalThis.fetch(input, init);
+    }) as typeof fetch;
+
+    const ev = new EventSource(
+      'http://localhost/sse',
+      {
+        disableRetry: true,
+      },
+      {
+        inputFetch: fetchFn,
+      },
+    );
+
+    ev.onopen = (event) => {
+      expect(event).toBeInstanceOf(Event);
+      expect(fetchFn).toHaveBeenCalled();
+      done();
+    };
+  });
+
   it('fails fatally if wrong content type is returned', (done) => {
     server.use(
       http.get('http://localhost/sse', () => {

--- a/src/eventsource.ts
+++ b/src/eventsource.ts
@@ -40,11 +40,15 @@ export class CustomEventSource extends EventTarget implements EventSource {
 
   private logger?: Logger;
 
+  private fetch: typeof fetch;
+
   constructor(
     url: string | URL,
     initDict?: EventSourceInit & EventSourceOptions,
+    { inputFetch } = { inputFetch: globalThis.fetch },
   ) {
     super();
+    this.fetch = inputFetch;
     this.url = url instanceof URL ? url.toString() : url;
     this.options = initDict ?? {};
     this.retry = initDict?.retry ?? 5000;
@@ -95,7 +99,7 @@ export class CustomEventSource extends EventTarget implements EventSource {
         signal: this.abortController?.signal,
       };
 
-      const response = await globalThis.fetch(this.url, fetchOptions);
+      const response = await this.fetch(this.url, fetchOptions);
 
       // https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource (Step 15)
       if (response.status !== 200) {


### PR DESCRIPTION
Add support for passing a custom `fetch` function, with default still being `globalThis.fetch`.

See [`@microsoft/fetch-event-source`](https://github.com/Azure/fetch-event-source/blob/a0529492576e094374602f24d5e64b3a271b4576/src/fetch.ts#L64) for a similar implementation.