### PR TITLE
Extend onopen/onerror events with the response object

### DIFF
--- a/src/eventsource.spec.ts
+++ b/src/eventsource.spec.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse as MswHttpResponse } from 'msw';
 import { server } from '../mocks/node';
-import { CustomEventSource as EventSource } from './eventsource';
+import { CustomEventSource as EventSource, CustomEvent } from './eventsource';
 import DoneCallback = jest.DoneCallback;
 
 describe('EventSource', () => {
@@ -128,8 +128,9 @@ describe('EventSource', () => {
       disableRetry: true,
     });
 
-    ev.onerror = () => {
+    ev.onerror = (event: CustomEvent) => {
       expect(ev.readyState).toEqual(ev.CLOSED);
+      expect(event.response?.status).toEqual(401);
       done();
     };
   });

--- a/src/eventsource.ts
+++ b/src/eventsource.ts
@@ -55,12 +55,12 @@ export class CustomEventSource extends EventTarget implements EventSource {
   public readyState = this.CONNECTING;
 
   // https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onopen
-  public onerror: ((this: EventSource, ev: Event) => any) | null = null;
+  public onerror: ((this: EventSource, ev: CustomEvent) => any) | null = null;
   // https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onmessage
   public onmessage: ((this: EventSource, ev: MessageEvent) => any) | null =
     null;
   // https://html.spec.whatwg.org/multipage/server-sent-events.html#handler-eventsource-onerror
-  public onopen: ((this: EventSource, ev: Event) => any) | null = null;
+  public onopen: ((this: EventSource, ev: CustomEvent) => any) | null = null;
 
   public onRetryDelayReceived:
     | ((this: EventSource, delay: number) => any)
@@ -160,7 +160,7 @@ export class CustomEventSource extends EventTarget implements EventSource {
         return this.failConnection(`Request failed with empty response body'`, response);
       }
 
-      this.announceConnection();
+      this.announceConnection(response);
 
       const reader: ReadableStreamDefaultReader<Uint8Array> =
         response.body.getReader();
@@ -255,10 +255,11 @@ export class CustomEventSource extends EventTarget implements EventSource {
   }
 
   // https://html.spec.whatwg.org/multipage/server-sent-events.html#announce-the-connection
-  private announceConnection() {
+  private announceConnection(response: Response) {
     this.logger?.debug('Connection established');
     this.readyState = this.OPEN;
-    const event = new Event('open');
+    const event: CustomEvent = new Event('open');
+    event.response = response;
     this.dispatchEvent(event);
     this.onopen?.(event);
   }


### PR DESCRIPTION
Event object was extended to optionally handle the response object, so that things like response status code can be used in the application logic.

Related issues: 
- #9 
