### PR TITLE
fix!: change credentials mode from "omit" to "same-origin" when set to false

### DIFF
--- a/eventsource.iml
+++ b/eventsource.iml
@@ -4,5 +4,6 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="@zxing" level="application" />
   </component>
 </module>


### PR DESCRIPTION
Changes the default value of the `credentials` option in fetch. 
Until now, it was set to `omit` if the `withCredentials` was falsy, as @oatkiller pointed out in #26. 
As per the spec, this value should be `same-site` by default and `include` if the `withCredentials` option is set to `true`.

Reference: https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-withcredentials-dev

> [!CAUTION]
> This is a breaking change, as users with `withCredentials` not set or set to false, will now send cookies to `same-site` instead of sending not them.
> Be sure that this is acceptable for your use case.

> [!TIP]
> If the `credentials` mode should still be set to `omit`, you can set the `omitCredentials` parameter to `true`. 
> If `withCredentials` is also set to `true`, `omitCredentials` will take precedence.

