### PR TITLE
chore!: remove deprecated extraOptions

### DIFF
--- a/src/eventsource.spec.ts
+++ b/src/eventsource.spec.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse as MswHttpResponse } from 'msw';
 import { server } from '../mocks/node';
-import { CustomEventSource as EventSource, CustomEvent } from './eventsource';
+import { CustomEvent, CustomEventSource as EventSource } from './eventsource';
 import DoneCallback = jest.DoneCallback;
 
 describe('EventSource', () => {
@@ -52,15 +52,10 @@ describe('EventSource', () => {
       return globalThis.fetch(input, init);
     }) as typeof fetch;
 
-    const ev = new EventSource(
-      'http://localhost/sse',
-      {
-        disableRetry: true,
-      },
-      {
-        fetchInput: fetchFn,
-      },
-    );
+    const ev = new EventSource('http://localhost/sse', {
+      disableRetry: true,
+      fetch: fetchFn,
+    });
 
     ev.onopen = (event) => {
       expect(event).toBeInstanceOf(Event);
@@ -76,13 +71,10 @@ describe('EventSource', () => {
       return globalThis.fetch(input, init);
     }) as typeof fetch;
 
-    const ev = new EventSource(
-      'http://localhost/sse',
-      {
-        disableRetry: true,
-        fetch: fetchFn,
-      },
-    );
+    const ev = new EventSource('http://localhost/sse', {
+      disableRetry: true,
+      fetch: fetchFn,
+    });
 
     ev.onopen = (event) => {
       expect(event).toBeInstanceOf(Event);

--- a/src/eventsource.ts
+++ b/src/eventsource.ts
@@ -36,16 +36,6 @@ export type EventSourceOptions = {
   omitCredentials?: boolean;
 } & Omit<RequestInit, 'cache' | 'credentials' | 'signal'>;
 
-/**
- * @deprecated
- */
-export type EventSourceExtraOptions = {
-  /**
-   * @deprecated Use {@link EventSourceOptions#fetch} instead
-   */
-  fetchInput?: typeof fetch;
-};
-
 export type CustomEvent = Event & {
   response?: Response;
 };
@@ -73,7 +63,6 @@ export class CustomEventSource extends EventTarget implements EventSource {
     | null = null;
 
   public readonly options: EventSourceInit & EventSourceOptions;
-  private readonly extraOptions?: EventSourceExtraOptions;
   private abortController?: AbortController;
   private timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
   private retry: number;
@@ -84,14 +73,9 @@ export class CustomEventSource extends EventTarget implements EventSource {
   constructor(
     url: string | URL,
     initDict?: EventSourceInit & EventSourceOptions,
-    /**
-     * @deprecated Use the related options in initDict
-     */
-    extraOptions?: EventSourceExtraOptions,
   ) {
     super();
     this.options = initDict ?? {};
-    this.extraOptions = extraOptions;
     this.url = url instanceof URL ? url.toString() : url;
     this.retry = initDict?.retry ?? 5000;
 
@@ -153,8 +137,6 @@ export class CustomEventSource extends EventTarget implements EventSource {
 
       const response = this.options.fetch
         ? await this.options.fetch(this.url, fetchOptions)
-        : this.extraOptions?.fetchInput
-        ? await this.extraOptions.fetchInput(this.url, fetchOptions)
         : await globalThis.fetch(this.url, fetchOptions);
 
       // https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource (Step 15)


### PR DESCRIPTION
Removes deprecated extraOptions, as they are all included in the `initDict`